### PR TITLE
Fixing 'PromiseKit: Pending Promise deallocated'

### DIFF
--- a/client/ForeverMaze/IsoScene.swift
+++ b/client/ForeverMaze/IsoScene.swift
@@ -99,7 +99,7 @@ class IsoScene: SKScene {
     }
     let touch = self.touches.first!
     let loc = touch.locationInView(self.view)
-    if distance(loc, p2: firstTouchLocation) < 10 {
+    if distance(loc, p2: firstTouchLocation) < 3 {
       return nil
     }
     let coords = loc - firstTouchLocation

--- a/client/ForeverMaze/Tile.swift
+++ b/client/ForeverMaze/Tile.swift
@@ -80,17 +80,16 @@ class Tile : GameSprite {
   override var description:String {
     return "<Tile \(position.x)x\(position.y)>: \(emotion)"
   }
-
+  
+  private var promiseLoad:Promise<Void>? = nil
   var loaded: Bool {
-    for id in self.objectIds {
-      if GameObject.cache[id] == nil {
-        return false
-      }
-    }
-    return true
+    return (promiseLoad?.resolved)!
   }
 
   func loadObjects() -> Promise<Void> {
-    return Data.loadObjects(self.objectIds)
+    if promiseLoad == nil {
+      promiseLoad = Data.loadObjects(self.objectIds)
+    }
+    return promiseLoad!
   }
 }


### PR DESCRIPTION
There were a few mis-uses of PromiseKit. This led to `PromiseKit: Pending Promise deallocated! This is usually a bug`. One key finding was that a call to `when()` with an empty array seems to lead to a promise which cannot be chained, likely it is improperly sealed (but I didn't dig into the PromiseKit source). I defaulted back to using a simple ternary to return a completed promise when the array size was zero. I also discovered some better patterns, such as `firstly`. 

There are still excessive load events being called, and generally object loading/unloading on the screen isn't quite perfect yet, but there are no more warnings from PromiseKit.
